### PR TITLE
even more demo ui tweaks

### DIFF
--- a/vscode/DEVELOPMENT.md
+++ b/vscode/DEVELOPMENT.md
@@ -1,0 +1,7 @@
+## Development
+
+-   Install the `tintinweb.graphviz-interactive-preview` and `ms-toolsai.jupyter` extensions if they're not already installed: `ext install tintinweb.graphviz-interactive-preview ms-toolsai.jupyter`
+-   Start the background build process: `npm run watch`
+-   Regenerate the api stubs: `npm run codegen`
+-   Do typechecking: `npm run lint`
+-   Fix formatting, some type stuff: `npm run fix`

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -23,14 +23,7 @@ This extension contributes the following settings:
 ## Dependencies
 
 -   Modality CLI: See the [Modality Client documentation](https://docs.auxon.io/modality/installation/client.html)
--   Python: The Jupter notebooks require Python 3, jupyter, pandas, and plotly packages to be installed
+-   Python: The Jupter notebooks require Python 3, jupyter, pandas, and plotly packages to be installed. We recommend
+    creating an isolated environment for this using `venv`.
 -   Extensions: The extension will automatically install the `tintinweb.graphviz-interactive-preview`
     and `ms-toolsai.jupyter` extensions by default when installed from the marketplace
-
-## Development
-
--   Install the `tintinweb.graphviz-interactive-preview` and `ms-toolsai.jupyter` extensions if they're not already installed: `ext install tintinweb.graphviz-interactive-preview ms-toolsai.jupyter`
--   Start the background build process: `npm run watch`
--   Regenerate the api stubs: `npm run codegen`
--   Do typechecking: `npm run lint`
--   Fix formatting, some type stuff: `npm run fix`

--- a/vscode/generated/src/modality-api.ts
+++ b/vscode/generated/src/modality-api.ts
@@ -342,6 +342,8 @@ export interface components {
       regions_passing: number;
       /** Format: int32 */
       regions_unknown: number;
+      /** Format: int64 */
+      spec_eval_at_utc_seconds: number;
       spec_eval_results_id: components["schemas"]["SpecEvalResultsId"];
       spec_name: string;
       spec_version_id: components["schemas"]["SpecVersionId"];
@@ -371,6 +373,8 @@ export interface components {
       created_by: string;
       name: string;
       version: components["schemas"]["SpecVersionId"];
+      /** @description Not uniquely identifying, but helps give a sense of ordering */
+      version_number: number;
     };
     /** @description Spec operation errors */
     SpecsError: OneOf<[{

--- a/vscode/src/events.ts
+++ b/vscode/src/events.ts
@@ -75,6 +75,8 @@ export class EventsTreeDataProvider implements vscode.TreeDataProvider<EventsTre
                 }
                 children.push(new EventNameTreeItemData(name, summary.n_instances, attrs));
             }
+
+            children.sort((a, b) => a.eventName.localeCompare(b.eventName));
             return children;
         } else {
             if (element instanceof EventNameTreeItemData) {

--- a/vscode/src/modality-api.json
+++ b/vscode/src/modality-api.json
@@ -2267,6 +2267,7 @@
                 "required": [
                     "spec_eval_results_id",
                     "spec_version_id",
+                    "spec_eval_at_utc_seconds",
                     "spec_name",
                     "behaviors",
                     "regions_passing",
@@ -2294,6 +2295,10 @@
                         "type": "integer",
                         "format": "int32",
                         "minimum": 0
+                    },
+                    "spec_eval_at_utc_seconds": {
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "spec_eval_results_id": {
                         "$ref": "#/components/schemas/SpecEvalResultsId"
@@ -2372,7 +2377,7 @@
             },
             "SpecVersionMetadata": {
                 "type": "object",
-                "required": ["name", "version", "created_at", "created_by"],
+                "required": ["name", "version", "version_number", "created_at", "created_by"],
                 "properties": {
                     "created_at": {
                         "type": "string"
@@ -2385,6 +2390,11 @@
                     },
                     "version": {
                         "$ref": "#/components/schemas/SpecVersionId"
+                    },
+                    "version_number": {
+                        "type": "integer",
+                        "description": "Not uniquely identifying, but helps give a sense of ordering",
+                        "minimum": 0
                     }
                 }
             },

--- a/vscode/src/specCoverage.ts
+++ b/vscode/src/specCoverage.ts
@@ -191,13 +191,10 @@ function behaviorViewModel(bhCov: api.BehaviorCoverage): BehaviorViewModel {
         .reduce((a, b) => a + b);
 
     let status: Status = "not-executed";
-    // TODO use api value once it exists
-    if (bhCov.test_counts.ever_executed && triggerCount > 0) {
-        if (bhCov.test_counts.ever_failed) {
-            status = "failed";
-        } else {
-            status = "passed";
-        }
+    if (bhCov.test_counts.ever_failed) {
+        status = "failed";
+    } else if (bhCov.test_counts.ever_executed && triggerCount > 0) {
+        status = "passed";
     }
 
     return {

--- a/vscode/src/specCoverage.ts
+++ b/vscode/src/specCoverage.ts
@@ -60,7 +60,7 @@ export class SpecCoverageProvider {
                 percentageBehaviorsCovered,
                 percentageCasesEverMatched: coverage.coverage_aggregates.percentage_cases_ever_matched,
             },
-            specs: coverage.spec_coverages.map(specViewModel),
+            specs: coverage.spec_coverages.map(specViewModel).sort((a, b) => a.name.localeCompare(b.name)),
             params,
             percentageBehaviorsCovered,
         });

--- a/vscode/src/specFileCommands.ts
+++ b/vscode/src/specFileCommands.ts
@@ -187,6 +187,10 @@ export function runConformEvalCommand(args: SpecEvalCommandArgs): Thenable<vscod
         }
     }
 
+    if (args.dry_run) {
+        commandArgs.push("--dry-run");
+    }
+
     const taskDef: vscode.TaskDefinition = {
         type: "auxon.conform.eval",
         command: conformPath,

--- a/vscode/src/specFileCommands.ts
+++ b/vscode/src/specFileCommands.ts
@@ -71,7 +71,7 @@ async function specDirEval(dir: vscode.Uri) {
     const specFiles = await recursivelyFindSpeqtrFilesBeneath(dir);
     const specNames = [];
     for (const specFile of specFiles) {
-        const specName = specPrefix + path.parse(specFile.fsPath).base;
+        const specName = specPrefix + path.parse(specFile.fsPath).name;
         await upsertSpec(specName, specFile);
         specNames.push(specName);
     }

--- a/vscode/src/specs.ts
+++ b/vscode/src/specs.ts
@@ -394,7 +394,7 @@ export class SpecVersionsTreeItemData extends SpecsTreeItemData {
                 } else {
                     icon = new vscode.ThemeIcon("file", new vscode.ThemeColor("symbolIcon.fileForeground"));
                 }
-                return new SpecVersionTreeItemData(versionMd.name, versionMd.version, icon);
+                return new SpecVersionTreeItemData(versionMd.name, versionMd.version, versionMd.version_number, icon);
             })
         );
     }
@@ -402,8 +402,13 @@ export class SpecVersionsTreeItemData extends SpecsTreeItemData {
 
 export class SpecVersionTreeItemData extends SpecsTreeItemData {
     contextValue = "specVersion";
-    constructor(public specName: api.SpecName, public specVersion: api.SpecVersionId, icon: vscode.ThemeIcon) {
-        super("Spec Version: " + specVersion);
+    constructor(
+        public specName: api.SpecName,
+        public specVersion: api.SpecVersionId,
+        public specVersionNumber: number,
+        icon: vscode.ThemeIcon
+    ) {
+        super("Spec Version: " + specVersionNumber);
         super.iconPath = icon;
     }
 

--- a/vscode/src/specs.ts
+++ b/vscode/src/specs.ts
@@ -452,7 +452,12 @@ export class SpecResultsTreeItemData extends SpecsTreeItemData {
 export class SpecResultTreeItemData extends SpecsTreeItemData {
     contextValue = "specResult";
     constructor(public evalOutcome: api.SpecEvalOutcomeHighlights) {
-        super("Spec Result: " + evalOutcome.spec_eval_results_id);
+        super("Spec Result");
+
+        const d = new Date(0);
+        d.setUTCSeconds(evalOutcome.spec_eval_at_utc_seconds);
+        super.description = d.toString();
+
         if (evalOutcome.regions_failing > 0) {
             super.iconPath = new vscode.ThemeIcon("testing-failed-icon");
         } else {


### PR DESCRIPTION
- Sort coverage report by spec name
- Don't include file extension in uploaded spec names
- Sort events panel by event name
- Fix dry-run spec eval
- Update api defs
- Fix failure accounting in coverage report
- Use version number in spec version tree item
- Use timestamp in spec result tree item
- Update README
